### PR TITLE
DSL-promises and FP

### DIFF
--- a/promises/02.01-async-pyramid-of-doom-tamed.js
+++ b/promises/02.01-async-pyramid-of-doom-tamed.js
@@ -1,0 +1,34 @@
+var db = require('./db/callbackPromise');
+
+var handleSet1 = function () {
+  return db.set('key2', 'value2');
+};
+
+var handleSet2 = function () {
+  return db.set('key3', 'value3');
+};
+
+var handleSet3 = function () {
+  return db.get('key1');
+};
+
+var handleGet1 = function (value) {
+  console.log('key1 - ' + value);
+};
+
+var handleError = function(err) {
+  console.log('An exception was thrown in one of the above promises');
+  console.log(JSON.stringify(err));
+};
+
+db.set('key1', 'value1')
+    .then(handleSet1)
+    .then(handleSet2)
+    .then(handleSet3)
+    .then(handleGet1)
+    .catch(handleError);
+
+// Example adapted from http://survivejs.com/common_problems/pyramid.html
+
+// splitted the then closures into their own functions, since they just work with no
+// parameters, to be able to create "almost" a DSL on the executable code.

--- a/promises/02.02-async-pyramid-of-doom-tamed-with-fp.js
+++ b/promises/02.02-async-pyramid-of-doom-tamed-with-fp.js
@@ -1,0 +1,30 @@
+var db = require('./db/callbackPromise');
+var _ = require('lodash');
+
+var handleSet = _.curry(function (keyToSet, valueToSet, value) {
+  return db.set(keyToSet, valueToSet);
+});
+
+var handleSetWithGet = _.curry(function(keyToGet, value) {
+  return db.get(keyToGet);
+});
+
+var handleGet = _.curry(function (key, value) {
+  console.log(key + value);
+});
+
+var handleError = function(err) {
+  console.log('An exception was thrown in one of the above promises');
+  console.log(JSON.stringify(err));
+};
+
+db.set('key1', 'value1')
+    .then(handleSet('key2', 'value2'))
+    .then(handleSet('key3', 'value3'))
+    .then(handleSetWithGet('key1'))
+    .then(handleGet('key1'))
+    .catch(handleError);
+
+// Example adapted from http://survivejs.com/common_problems/pyramid.html
+
+// added currying to the solution, to be able to reuse simple generic functions on the then


### PR DESCRIPTION
Hey @faceleg 
Added two more examples
02.01 is externalizing the closures of each then or catch, to its own function, to be able to create a reasonable DSL.
02.02 is applying currying to generalize the externalized functions, to promote better reuse

Cheers mate
